### PR TITLE
Add imagemanifest vulnerability policy

### DIFF
--- a/packages/boms/acm-sandbox/30-pb-sandbox.yaml
+++ b/packages/boms/acm-sandbox/30-pb-sandbox.yaml
@@ -14,3 +14,7 @@ subjects:
   namespace: acm-sandbox
   kind: Policy
   apiGroup: policy.open-cluster-management.io
+- name: pl-imagemanifestvuln
+  namespace: acm-sandbox
+  kind: Policy
+  apiGroup: policy.open-cluster-management.io

--- a/policies/policy-imagemanifestvuln/base/kustomization.yaml
+++ b/policies/policy-imagemanifestvuln/base/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- sb-managed-cluster-info.yaml
-- sb-imagemanifestvuln.yaml
+- pl-imagemanifestvuln.yaml

--- a/policies/policy-imagemanifestvuln/base/pl-imagemanifestvuln.yaml
+++ b/policies/policy-imagemanifestvuln/base/pl-imagemanifestvuln.yaml
@@ -1,0 +1,69 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: pl-imagemanifestvuln
+  annotations:
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/categories: SI System and Information Integrity
+    policy.open-cluster-management.io/controls: SI-4 Information System Monitoring
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-imagemanifestvuln-example-sub
+        spec:
+          remediationAction: inform # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
+          severity: high
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: Subscription
+                metadata:
+                  name: container-security-operator
+                  namespace: openshift-operators
+                spec:
+                  # channel: quay-v3.3 # specify a specific channel if desired
+                  installPlanApproval: Automatic
+                  name: container-security-operator
+                  source: redhat-operators
+                  sourceNamespace: openshift-marketplace
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-imagemanifestvuln-status
+        spec:
+          remediationAction: inform  # will be overridden by remediationAction in parent policy
+          severity: high
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: ClusterServiceVersion
+                metadata:
+                  namespace: openshift-operators
+                spec:
+                  displayName: Quay Container Security
+                status:
+                  phase: Succeeded   # check the csv status to determine if operator is running or not
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-imagemanifestvuln-example-imv
+        spec:
+          remediationAction: inform # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
+          severity: high
+          namespaceSelector:
+            exclude: ["kube-*"]
+            include: ["*"]
+          object-templates:
+            - complianceType: mustnothave # mustnothave any ImageManifestVuln object
+              objectDefinition:
+                apiVersion: secscan.quay.redhat.com/v1alpha1
+                kind: ImageManifestVuln # checking for a kind

--- a/policies/policy-imagemanifestvuln/sandbox/kustomization.yaml
+++ b/policies/policy-imagemanifestvuln/sandbox/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- ../base
+
+# namespace: my-namespace
+# namePrefix: dev-
+# nameSuffix: "-001"
+# commonLabels:
+#   app: bingo
+
+commonAnnotations:
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/categories: SI System and Information Integrity
+    policy.open-cluster-management.io/controls: SI-4 Information System Monitoring

--- a/policies/subscriptions/base/sb-imagemanifestvuln.yaml
+++ b/policies/subscriptions/base/sb-imagemanifestvuln.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: sb-imagemanifestvuln
+  namespace: acm-sandbox
+  labels:
+    subscription-pause: "false"
+  annotations:
+    apps.open-cluster-management.io/github-path: policies/policy-imagemanifestvuln/sandbox
+spec:
+  channel: acm-channels/cluster-gitops
+  placement:
+    local: true


### PR DESCRIPTION
Add policy to install Container Security Operator and check that no ImageManifestVuln objects exist

ImageManifestVuln policy from ACM [policy collection](https://github.com/stolostron/policy-collection/tree/main/stable).

