### PR TITLE
Add policy for OpenShift CIS security benchmark compliance

### DIFF
--- a/packages/boms/acm-sandbox/30-pb-sandbox.yaml
+++ b/packages/boms/acm-sandbox/30-pb-sandbox.yaml
@@ -22,3 +22,7 @@ subjects:
   namespace: acm-sandbox
   kind: Policy
   apiGroup: policy.open-cluster-management.io
+- name: pl-compliance-operator-cis
+  namespace: acm-sandbox
+  kind: Policy
+  apiGroup: policy.open-cluster-management.io

--- a/policies/policy-compliance-operator-cis/base/kustomization.yaml
+++ b/policies/policy-compliance-operator-cis/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- pl-compliance-operator-cis.yaml

--- a/policies/policy-compliance-operator-cis/base/pl-compliance-operator-cis.yaml
+++ b/policies/policy-compliance-operator-cis/base/pl-compliance-operator-cis.yaml
@@ -1,0 +1,78 @@
+# This policy assumes that the Compliance Operator is installed and running on
+# the managed clusters. It deploys a scan that checks the master and worker
+# nodes, and verifies compliance with the OpenShift CIS security benchmark.
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: pl-compliance-operator-cis
+  annotations:
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-6 Configuration Settings
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: compliance-cis-scan
+        spec:
+          remediationAction: inform
+          severity: high
+          object-templates:
+            - complianceType: musthave # this template creates ScanSettingBinding:cis
+              objectDefinition:
+                apiVersion: compliance.openshift.io/v1alpha1
+                kind: ScanSettingBinding
+                metadata:
+                  name: cis
+                  namespace: openshift-compliance
+                profiles:
+                - apiGroup: compliance.openshift.io/v1alpha1
+                  kind: Profile
+                  name: ocp4-cis
+                - apiGroup: compliance.openshift.io/v1alpha1
+                  kind: Profile
+                  name: ocp4-cis-node
+                settingsRef:
+                  apiGroup: compliance.openshift.io/v1alpha1
+                  kind: ScanSetting
+                  name: default
+    - objectDefinition: 
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: compliance-suite-cis
+        spec:
+          remediationAction: inform
+          severity: high
+          object-templates:
+            - complianceType: musthave # this template checks if scan has completed by checking the status field
+              objectDefinition:
+                apiVersion: compliance.openshift.io/v1alpha1
+                kind: ComplianceSuite
+                metadata:
+                  name: cis
+                  namespace: openshift-compliance
+                status:
+                  phase: DONE
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: compliance-suite-cis-results
+        spec:
+          remediationAction: inform
+          severity: high
+          object-templates:
+            - complianceType: mustnothave # this template reports the results for scan suite: cis by looking at ComplianceCheckResult CRs
+              objectDefinition:
+                apiVersion: compliance.openshift.io/v1alpha1
+                kind: ComplianceCheckResult
+                metadata:
+                  namespace: openshift-compliance
+                  labels:
+                    compliance.openshift.io/check-status: FAIL
+                    compliance.openshift.io/suite: cis

--- a/policies/policy-compliance-operator-cis/sandbox/kustomization.yaml
+++ b/policies/policy-compliance-operator-cis/sandbox/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/policies/subscriptions/base/kustomization.yaml
+++ b/policies/subscriptions/base/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - sb-managed-cluster-info.yaml
 - sb-imagemanifestvuln.yaml
 - sb-compliance-operator-install.yaml
+- sb-compliance-operator-cis.yaml

--- a/policies/subscriptions/base/sb-compliance-operator-cis.yaml
+++ b/policies/subscriptions/base/sb-compliance-operator-cis.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: sb-compliance-operator-cis
+  namespace: acm-sandbox
+  labels:
+    subscription-pause: "false"
+  annotations:
+    apps.open-cluster-management.io/github-path: policies/policy-compliance-operator-cis/sandbox
+spec:
+  channel: acm-channels/cluster-gitops
+  placement:
+    local: true
+  


### PR DESCRIPTION
The policy assumes the compliance operator is installed. It deploys a scan that will check the master and worker nodes and verifies compliance with the OpenShift CIS security benchmark.

CIS policy fetched from https://github.com/stolostron/policy-collection/tree/main/stable/CM-Configuration-Management
